### PR TITLE
setup nn

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -64,7 +64,7 @@
         await initPlayer();
     });
 </script>
-    
+
 <body>
     <div id="aplayer"></div>
     <h1>Meting-API</h1>
@@ -87,7 +87,11 @@
     &nbsp;&nbsp;&nbsp;id: 类型ID（封面ID/单曲ID/歌单ID）<br />
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;（id 必须指定，在使用其它功能 比如搜索 时，请将 id 指定为 0 ）<br />
     <br />
+    &nbsp;&nbsp;&nbsp;picsize: 歌曲封面大小（仅使用封面功能时 可选 携带，指定纯数字）<br />
+    <br />
     &nbsp;&nbsp;&nbsp;keyword: 搜索关键词（仅使用搜索功能时携带）<br />
+    <br />
+    &nbsp;&nbsp;&nbsp;br: 歌曲最高音质（仅使用单曲功能时 可选 携带，目前仅网易云有效，指定纯数字，如 1411 即 1411kbps ）<br />
     <br />
     &nbsp;&nbsp;&nbsp;yrc: 网易云音乐逐字歌词解析开关，开启后优先解析逐字歌词。<br />
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;False 禁用(默认)<br />

--- a/public/index.php
+++ b/public/index.php
@@ -23,6 +23,10 @@
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;song 单曲<br />
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;playlist 歌单<br /><br />
     id: 类型ID（封面ID/单曲ID/歌单ID）<br />
+    <br /><br />
+    yrc: 网易云音乐逐字歌词解析开关，开启后优先解析逐字歌词。<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;False 禁用(默认)<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;True 启用<br />
     <br />
     GitHub：<a href="https://github.com/injahow/meting-api" target="_blank">meting-api</a>，此API基于 <a href="https://github.com/metowolf/Meting" target="_blank">Meting</a> 构建。<br /><br />
     例如：<a href="<?php echo API_URI ?>?type=url&id=416892104" target="_blank"><?php echo API_URI ?>?type=url&id=416892104</a><br />

--- a/public/index.php
+++ b/public/index.php
@@ -44,7 +44,7 @@
     };
 
     const initPlayer = async () => {
-        const playlist = await getPlayerList('netease', 'playlist', '3035221869');
+        const playlist = await getPlayerList('netease', 'playlist', '2619366284');
 
         const ap = new APlayer({
             container: document.getElementById('aplayer'),

--- a/public/index.php
+++ b/public/index.php
@@ -5,33 +5,99 @@
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
     <link rel="shortcut icon" href="favicon.png">
     <title>Meting-API</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/aplayer/1.10.1/APlayer.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/aplayer/1.10.1/APlayer.min.js"></script>
 </head>
 
+<script>
+    const getPlayerList = async (server, type, id, yrc) => {
+        const res = await fetch(
+            `<?php echo API_URI ?>?server=netease&type=playlist&id=2619366284&yrc=false`,
+        );
+        const data = await res.json();
+
+        if (data[0].url.startsWith("@")) {
+            // eslint-disable-next-line no-unused-vars
+            const [handle, jsonpCallback, jsonpCallbackFunction, url] = data[0].url.split("@").slice(1);
+            const jsonpData = await fetchJsonp(url).then((res) => res.json());
+            const domain = (
+                jsonpData.req_0.data.sip.find((i) => !i.startsWith("http://ws")) ||
+                jsonpData.req_0.data.sip[0]
+            ).replace("http://", "https://");
+
+            return data.map((v, i) => ({
+                name: v.name || v.title,
+                artist: v.artist || v.author,
+                url: domain + jsonpData.req_0.data.midurlinfo[i].purl,
+                cover: v.cover || v.pic,
+                lrc: v.lrc,
+            }));
+        } else {
+            return data.map((v) => ({
+                name: v.name || v.title,
+                artist: v.artist || v.author,
+                url: v.url,
+                cover: v.cover || v.pic,
+                lrc: v.lrc,
+            }));
+        }
+    };
+
+    const initPlayer = async () => {
+        const playlist = await getPlayerList('netease', 'playlist', '3035221869');
+
+        const ap = new APlayer({
+            container: document.getElementById('aplayer'),
+            audio: playlist,
+            autoplay: true,
+            fixed: true,
+            volume: 0.7,
+            mutex: true,
+            loop: "all",
+            order: "random",
+            preload: "auto",
+            lrcType: 3,
+        });
+    };
+
+    window.addEventListener('DOMContentLoaded', async () => {
+        await initPlayer();
+    });
+</script>
+    
 <body>
+    <div id="aplayer"></div>
+    <h1>Meting-API</h1>
     <h2>参数说明</h2>
-    server: 数据源
+    &nbsp;&nbsp;&nbsp;server: 数据源
     <br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;netease 网易云音乐(默认)<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tencent QQ音乐<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;netease 网易云音乐(默认)<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tencent QQ音乐<br />
     <br />
-    type: 类型<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name 歌曲名<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;artist 歌手<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;url 链接<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;pic 封面<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;lrc 歌词<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;song 单曲<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;playlist 歌单<br /><br />
-    id: 类型ID（封面ID/单曲ID/歌单ID）<br />
+    &nbsp;&nbsp;&nbsp;type: 类型<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name 歌曲名<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;artist 歌手<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;url 链接<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;pic 封面<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;lrc 歌词<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;song 单曲<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;playlist 歌单<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;search 搜索<br />
+    <br />
+    &nbsp;&nbsp;&nbsp;id: 类型ID（封面ID/单曲ID/歌单ID）<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;（id 必须指定，在使用其它功能 比如搜索 时，请将 id 指定为 0 ）<br />
+    <br />
+    &nbsp;&nbsp;&nbsp;keyword: 搜索关键词（仅使用搜索功能时携带）<br />
+    <br />
+    &nbsp;&nbsp;&nbsp;yrc: 网易云音乐逐字歌词解析开关，开启后优先解析逐字歌词。<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;False 禁用(默认)<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;True 启用<br />
     <br /><br />
-    yrc: 网易云音乐逐字歌词解析开关，开启后优先解析逐字歌词。<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;False 禁用(默认)<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;True 启用<br />
-    <br />
-    GitHub：<a href="https://github.com/injahow/meting-api" target="_blank">meting-api</a>，此API基于 <a href="https://github.com/metowolf/Meting" target="_blank">Meting</a> 构建。<br /><br />
-    例如：<a href="<?php echo API_URI ?>?type=url&id=416892104" target="_blank"><?php echo API_URI ?>?type=url&id=416892104</a><br />
-    <a href="<?php echo API_URI ?>?type=song&id=591321" target="_blank" style="padding-left:48px"><?php echo API_URI ?>?type=song&id=591321</a><br />
-    <a href="<?php echo API_URI ?>?type=playlist&id=2619366284" target="_blank" style="padding-left:48px"><?php echo API_URI ?>?type=playlist&id=2619366284</a>
+    GitHub：<a href="https://github.com/injahow/meting-api" target="_blank">meting-api</a>，此API基于 <a href="https://github.com/metowolf/Meting" target="_blank">Meting</a> 构建。当前为<a href="https://github.com/NanoRocky/meting-api" target="_blank">酪灰修改版本</a>。<br /><br /><br />
+    例如：<a href="<?php echo API_URI ?>?server=netease&type=url&id=416892104" target="_blank"><?php echo API_URI ?>?server=netease&type=url&id=416892104</a><br />
+    <a href="<?php echo API_URI ?>?server=netease&type=song&id=591321" target="_blank" style="padding-left:48px"><?php echo API_URI ?>?server=netease&type=song&id=591321</a><br />
+    <a href="<?php echo API_URI ?>?server=netease&type=playlist&id=2619366284&yrc=true" target="_blank" style="padding-left:48px"><?php echo API_URI ?>?server=netease&type=playlist&id=2619366284&yrc=true</a><br />
+    <a href="<?php echo API_URI ?>?server=netease&type=search&id=0&yrc=true&keyword=寄往未来的信" target="_blank" style="padding-left:48px"><?php echo API_URI ?>?server=netease&type=search&id=0&yrc=true&keyword=寄往未来的信</a><br />
 </body>
 
 </html>

--- a/src/Meting.php
+++ b/src/Meting.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Meting music framework
  * https://i-meto.com
@@ -28,7 +29,8 @@ class Meting
     public $header;
     private $temp;
 
-    public function yrc($value = false) {
+    public function yrc($value = false)
+    {
         $this->yrc = $value;
         return $this;
     }
@@ -75,7 +77,7 @@ class Meting
         }
         if ($api['method'] == 'GET') {
             if (isset($api['body'])) {
-                $api['url'] .= '?'.http_build_query($api['body']);
+                $api['url'] .= '?' . http_build_query($api['body']);
                 $api['body'] = null;
             }
         }
@@ -101,7 +103,7 @@ class Meting
     private function curl($url, $payload = null, $headerOnly = 0)
     {
         $header = array_map(function ($k, $v) {
-            return $k.': '.$v;
+            return $k . ': ' . $v;
         }, array_keys($this->header), $this->header);
         $curl = curl_init();
         if (!is_null($payload)) {
@@ -156,7 +158,7 @@ class Meting
         if (!isset($raw[0]) && count($raw)) {
             $raw = array($raw);
         }
-        $result = array_map(array($this, 'format_'.$this->server), $raw);
+        $result = array_map(array($this, 'format_' . $this->server), $raw);
 
         return json_encode($result);
     }
@@ -165,105 +167,105 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            $api = array(
-                'method' => 'POST',
-                'url'    => 'https://music.163.com/api/cloudsearch/pc',
-                'body'   => array(
-                    's'      => $keyword,
-                    'type'   => isset($option['type']) ? $option['type'] : 1,
-                    'limit'  => isset($option['limit']) ? $option['limit'] : 100000,
-                    'total'  => 'true',
-                    'offset' => isset($option['page']) && isset($option['limit']) ? ($option['page'] - 1) * $option['limit'] : 0,
-                ),
-                'encode' => 'netease_AESCBC',
-                'format' => 'result.songs',
-            );
-            break;
-            case 'tencent':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://c.y.qq.com/soso/fcgi-bin/client_search_cp',
-                'body'   => array(
-                    'format'   => 'json',
-                    'p'        => isset($option['page']) ? $option['page'] : 1,
-                    'n'        => isset($option['limit']) ? $option['limit'] : 30,
-                    'w'        => $keyword,
-                    'aggr'     => 1,
-                    'lossless' => 1,
-                    'cr'       => 1,
-                    'new_json' => 1,
-                ),
-                'format' => 'data.song.list',
-            );
-            break;
-            case 'xiami':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.search.searchservice.searchsongs/1.0/',
-                'body'   => array(
-                    'data' => array(
-                        'key'      => $keyword,
-                        'pagingVO' => array(
-                            'page'     => isset($option['page']) ? $option['page'] : 1,
-                            'pageSize' => isset($option['limit']) ? $option['limit'] : 30,
-                        ),
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'https://music.163.com/api/cloudsearch/pc',
+                    'body'   => array(
+                        's'      => $keyword,
+                        'type'   => isset($option['type']) ? $option['type'] : 1,
+                        'limit'  => isset($option['limit']) ? $option['limit'] : 50,
+                        'total'  => 'true',
+                        'offset' => isset($option['page']) && isset($option['limit']) ? ($option['page'] - 1) * $option['limit'] : 0,
                     ),
-                    'r' => 'mtop.alimusic.search.searchservice.searchsongs',
-                ),
-                'encode' => 'xiami_sign',
-                'format' => 'data.data.songs',
-            );
-            break;
+                    'encode' => 'netease_AESCBC',
+                    'format' => 'result.songs',
+                );
+                break;
+            case 'tencent':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://c.y.qq.com/soso/fcgi-bin/client_search_cp',
+                    'body'   => array(
+                        'format'   => 'json',
+                        'p'        => isset($option['page']) ? $option['page'] : 1,
+                        'n'        => isset($option['limit']) ? $option['limit'] : 50,
+                        'w'        => $keyword,
+                        'aggr'     => 1,
+                        'lossless' => 1,
+                        'cr'       => 1,
+                        'new_json' => 1,
+                    ),
+                    'format' => 'data.song.list',
+                );
+                break;
+            case 'xiami':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.search.searchservice.searchsongs/1.0/',
+                    'body'   => array(
+                        'data' => array(
+                            'key'      => $keyword,
+                            'pagingVO' => array(
+                                'page'     => isset($option['page']) ? $option['page'] : 1,
+                                'pageSize' => isset($option['limit']) ? $option['limit'] : 30,
+                            ),
+                        ),
+                        'r' => 'mtop.alimusic.search.searchservice.searchsongs',
+                    ),
+                    'encode' => 'xiami_sign',
+                    'format' => 'data.data.songs',
+                );
+                break;
             case 'kugou':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://mobilecdn.kugou.com/api/v3/search/song',
-                'body'   => array(
-                    'api_ver'   => 1,
-                    'area_code' => 1,
-                    'correct'   => 1,
-                    'pagesize'  => isset($option['limit']) ? $option['limit'] : 30,
-                    'plat'      => 2,
-                    'tag'       => 1,
-                    'sver'      => 5,
-                    'showtype'  => 10,
-                    'page'      => isset($option['page']) ? $option['page'] : 1,
-                    'keyword'   => $keyword,
-                    'version'   => 8990,
-                ),
-                'format' => 'data.info',
-            );
-            break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://mobilecdn.kugou.com/api/v3/search/song',
+                    'body'   => array(
+                        'api_ver'   => 1,
+                        'area_code' => 1,
+                        'correct'   => 1,
+                        'pagesize'  => isset($option['limit']) ? $option['limit'] : 30,
+                        'plat'      => 2,
+                        'tag'       => 1,
+                        'sver'      => 5,
+                        'showtype'  => 10,
+                        'page'      => isset($option['page']) ? $option['page'] : 1,
+                        'keyword'   => $keyword,
+                        'version'   => 8990,
+                    ),
+                    'format' => 'data.info',
+                );
+                break;
             case 'baidu':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
-                'body'   => array(
-                    'from'      => 'qianqianmini',
-                    'method'    => 'baidu.ting.search.merge',
-                    'isNew'     => 1,
-                    'platform'  => 'darwin',
-                    'page_no'   => isset($option['page']) ? $option['page'] : 1,
-                    'query'     => $keyword,
-                    'version'   => '11.2.1',
-                    'page_size' => isset($option['limit']) ? $option['limit'] : 30,
-                ),
-                'format' => 'result.song_info.song_list',
-            );
-            break;
-			case 'kuwo':
-			$api = array(
-				'method' => 'GET',
-				'url'    => 'http://www.kuwo.cn/api/www/search/searchMusicBykeyWord',
-				'body'   => array(
-					'key'         => $keyword,
-					'pn'          => isset($option['page']) ? $option['page'] : 1,
-					'rn'          => isset($option['limit']) ? $option['limit'] : 30,
-					'httpsStatus' => 1,
-				),
-				'format' => 'data.list',
-			);
-			break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'body'   => array(
+                        'from'      => 'qianqianmini',
+                        'method'    => 'baidu.ting.search.merge',
+                        'isNew'     => 1,
+                        'platform'  => 'darwin',
+                        'page_no'   => isset($option['page']) ? $option['page'] : 1,
+                        'query'     => $keyword,
+                        'version'   => '11.2.1',
+                        'page_size' => isset($option['limit']) ? $option['limit'] : 30,
+                    ),
+                    'format' => 'result.song_info.song_list',
+                );
+                break;
+            case 'kuwo':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://www.kuwo.cn/api/www/search/searchMusicBykeyWord',
+                    'body'   => array(
+                        'key'         => $keyword,
+                        'pn'          => isset($option['page']) ? $option['page'] : 1,
+                        'rn'          => isset($option['limit']) ? $option['limit'] : 30,
+                        'httpsStatus' => 1,
+                    ),
+                    'format' => 'data.list',
+                );
+                break;
         }
 
         return $this->exec($api);
@@ -273,81 +275,81 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            $api = array(
-                'method' => 'POST',
-                'url'    => 'https://music.163.com/api/v3/song/detail/',
-                'body'   => array(
-                    'c' => '[{"id":'.$id.',"v":0}]',
-                ),
-                'encode' => 'netease_AESCBC',
-                'format' => 'songs',
-            );
-            break;
-            case 'tencent':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_play_single_song.fcg',
-                'body'   => array(
-                    'songmid'  => $id,
-                    'platform' => 'yqq',
-                    'format'   => 'json',
-                ),
-                'format' => 'data',
-            );
-            break;
-            case 'xiami':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.songservice.getsongdetail/1.0/',
-                'body'   => array(
-                    'data' => array(
-                        'songId' => $id,
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'https://music.163.com/api/v3/song/detail/',
+                    'body'   => array(
+                        'c' => '[{"id":' . $id . ',"v":0}]',
                     ),
-                    'r' => 'mtop.alimusic.music.songservice.getsongdetail',
-                ),
-                'encode' => 'xiami_sign',
-                'format' => 'data.data.songDetail',
-            );
-            break;
+                    'encode' => 'netease_AESCBC',
+                    'format' => 'songs',
+                );
+                break;
+            case 'tencent':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_play_single_song.fcg',
+                    'body'   => array(
+                        'songmid'  => $id,
+                        'platform' => 'yqq',
+                        'format'   => 'json',
+                    ),
+                    'format' => 'data',
+                );
+                break;
+            case 'xiami':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.songservice.getsongdetail/1.0/',
+                    'body'   => array(
+                        'data' => array(
+                            'songId' => $id,
+                        ),
+                        'r' => 'mtop.alimusic.music.songservice.getsongdetail',
+                    ),
+                    'encode' => 'xiami_sign',
+                    'format' => 'data.data.songDetail',
+                );
+                break;
             case 'kugou':
-            $api = array(
-                'method' => 'POST',
-                'url'    => 'http://m.kugou.com/app/i/getSongInfo.php',
-                'body'   => array(
-                    'cmd'  => 'playInfo',
-                    'hash' => $id,
-                    'from' => 'mkugou',
-                ),
-                'format' => '',
-            );
-            break;
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'http://m.kugou.com/app/i/getSongInfo.php',
+                    'body'   => array(
+                        'cmd'  => 'playInfo',
+                        'hash' => $id,
+                        'from' => 'mkugou',
+                    ),
+                    'format' => '',
+                );
+                break;
             case 'baidu':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
-                'body'   => array(
-                    'from'     => 'qianqianmini',
-                    'method'   => 'baidu.ting.song.getInfos',
-                    'songid'   => $id,
-                    'res'      => 1,
-                    'platform' => 'darwin',
-                    'version'  => '1.0.0',
-                ),
-                'encode' => 'baidu_AESCBC',
-                'format' => 'songinfo',
-            );
-            break;
-			case 'kuwo':
-			$api = array(
-				'method' => 'GET',
-				'url'    => 'http://www.kuwo.cn/api/www/music/musicInfo',
-				'body'   => array(
-					'mid'         => $id,
-					'httpsStatus' => 1,
-				),
-				'format' => 'data',
-			);
-			break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'body'   => array(
+                        'from'     => 'qianqianmini',
+                        'method'   => 'baidu.ting.song.getInfos',
+                        'songid'   => $id,
+                        'res'      => 1,
+                        'platform' => 'darwin',
+                        'version'  => '1.0.0',
+                    ),
+                    'encode' => 'baidu_AESCBC',
+                    'format' => 'songinfo',
+                );
+                break;
+            case 'kuwo':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://www.kuwo.cn/api/www/music/musicInfo',
+                    'body'   => array(
+                        'mid'         => $id,
+                        'httpsStatus' => 1,
+                    ),
+                    'format' => 'data',
+                );
+                break;
         }
 
         return $this->exec($api);
@@ -357,90 +359,90 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            $api = array(
-                'method' => 'POST',
-                'url'    => 'https://music.163.com/api/v1/album/'.$id,
-                'body'   => array(
-                    'total'         => 'true',
-                    'offset'        => '0',
-                    'id'            => $id,
-                    'limit'         => '100000',
-                    'ext'           => 'true',
-                    'private_cloud' => 'true',
-                ),
-                'encode' => 'netease_AESCBC',
-                'format' => 'songs',
-            );
-            break;
-            case 'tencent':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_v8_album_detail_cp.fcg',
-                'body'   => array(
-                    'albummid' => $id,
-                    'platform' => 'mac',
-                    'format'   => 'json',
-                    'newsong'  => 1,
-                ),
-                'format' => 'data.getSongInfo',
-            );
-            break;
-            case 'xiami':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.albumservice.getalbumdetail/1.0/',
-                'body'   => array(
-                    'data' => array(
-                        'albumId' => $id,
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'https://music.163.com/api/v1/album/' . $id,
+                    'body'   => array(
+                        'total'         => 'true',
+                        'offset'        => '0',
+                        'id'            => $id,
+                        'limit'         => '100000',
+                        'ext'           => 'true',
+                        'private_cloud' => 'true',
                     ),
-                    'r' => 'mtop.alimusic.music.albumservice.getalbumdetail',
-                ),
-                'encode' => 'xiami_sign',
-                'format' => 'data.data.albumDetail.songs',
-            );
-            break;
+                    'encode' => 'netease_AESCBC',
+                    'format' => 'songs',
+                );
+                break;
+            case 'tencent':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_v8_album_detail_cp.fcg',
+                    'body'   => array(
+                        'albummid' => $id,
+                        'platform' => 'mac',
+                        'format'   => 'json',
+                        'newsong'  => 1,
+                    ),
+                    'format' => 'data.getSongInfo',
+                );
+                break;
+            case 'xiami':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.albumservice.getalbumdetail/1.0/',
+                    'body'   => array(
+                        'data' => array(
+                            'albumId' => $id,
+                        ),
+                        'r' => 'mtop.alimusic.music.albumservice.getalbumdetail',
+                    ),
+                    'encode' => 'xiami_sign',
+                    'format' => 'data.data.albumDetail.songs',
+                );
+                break;
             case 'kugou':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://mobilecdn.kugou.com/api/v3/album/song',
-                'body'   => array(
-                    'albumid'   => $id,
-                    'area_code' => 1,
-                    'plat'      => 2,
-                    'page'      => 1,
-                    'pagesize'  => -1,
-                    'version'   => 8990,
-                ),
-                'format' => 'data.info',
-            );
-            break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://mobilecdn.kugou.com/api/v3/album/song',
+                    'body'   => array(
+                        'albumid'   => $id,
+                        'area_code' => 1,
+                        'plat'      => 2,
+                        'page'      => 1,
+                        'pagesize'  => -1,
+                        'version'   => 8990,
+                    ),
+                    'format' => 'data.info',
+                );
+                break;
             case 'baidu':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
-                'body'   => array(
-                    'from'     => 'qianqianmini',
-                    'method'   => 'baidu.ting.album.getAlbumInfo',
-                    'album_id' => $id,
-                    'platform' => 'darwin',
-                    'version'  => '11.2.1',
-                ),
-                'format' => 'songlist',
-            );
-            break;
-			case 'kuwo':
-			$api = array(
-				'method' => 'GET',
-				'url'    => 'http://www.kuwo.cn/api/www/album/albumInfo',
-				'body'   => array(
-					'albumId'     => $id,
-                    'pn'          => 1,
-                    'rn'          => 1000,
-					'httpsStatus' => 1,
-				),
-				'format' => 'data.musicList',
-			);
-			break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'body'   => array(
+                        'from'     => 'qianqianmini',
+                        'method'   => 'baidu.ting.album.getAlbumInfo',
+                        'album_id' => $id,
+                        'platform' => 'darwin',
+                        'version'  => '11.2.1',
+                    ),
+                    'format' => 'songlist',
+                );
+                break;
+            case 'kuwo':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://www.kuwo.cn/api/www/album/albumInfo',
+                    'body'   => array(
+                        'albumId'     => $id,
+                        'pn'          => 1,
+                        'rn'          => 1000,
+                        'httpsStatus' => 1,
+                    ),
+                    'format' => 'data.musicList',
+                );
+                break;
         }
 
         return $this->exec($api);
@@ -450,98 +452,97 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            $api = array(
-                'method' => 'POST',
-                'url'    => 'https://music.163.com/api/v1/artist/'.$id,
-                'body'   => array(
-                    'ext'           => 'true',
-                    'private_cloud' => 'true',
-                    'ext'           => 'true',
-                    'top'           => $limit,
-                    'id'            => $id,
-                ),
-                'encode' => 'netease_AESCBC',
-                'format' => 'hotSongs',
-            );
-            break;
-            case 'tencent':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_v8_singer_track_cp.fcg',
-                'body'   => array(
-                    'singermid' => $id,
-                    'begin'     => 0,
-                    'num'       => $limit,
-                    'order'     => 'listen',
-                    'platform'  => 'mac',
-                    'newsong'   => 1,
-                ),
-                'format' => 'data.list',
-            );
-            break;
-            case 'xiami':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.songservice.getartistsongs/1.0/',
-                'body'   => array(
-                    'data' => array(
-                        'artistId' => $id,
-                        'pagingVO' => array(
-                            'page'     => 1,
-                            'pageSize' => $limit,
-                        ),
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'https://music.163.com/api/v1/artist/' . $id,
+                    'body'   => array(
+                        'ext'           => 'true',
+                        'private_cloud' => 'true',
+                        'top'           => $limit,
+                        'id'            => $id,
                     ),
-                    'r' => 'mtop.alimusic.music.songservice.getartistsongs',
-                ),
-                'encode' => 'xiami_sign',
-                'format' => 'data.data.songs',
-            );
-            break;
+                    'encode' => 'netease_AESCBC',
+                    'format' => 'hotSongs',
+                );
+                break;
+            case 'tencent':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_v8_singer_track_cp.fcg',
+                    'body'   => array(
+                        'singermid' => $id,
+                        'begin'     => 0,
+                        'num'       => $limit,
+                        'order'     => 'listen',
+                        'platform'  => 'mac',
+                        'newsong'   => 1,
+                    ),
+                    'format' => 'data.list',
+                );
+                break;
+            case 'xiami':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.songservice.getartistsongs/1.0/',
+                    'body'   => array(
+                        'data' => array(
+                            'artistId' => $id,
+                            'pagingVO' => array(
+                                'page'     => 1,
+                                'pageSize' => $limit,
+                            ),
+                        ),
+                        'r' => 'mtop.alimusic.music.songservice.getartistsongs',
+                    ),
+                    'encode' => 'xiami_sign',
+                    'format' => 'data.data.songs',
+                );
+                break;
             case 'kugou':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://mobilecdn.kugou.com/api/v3/singer/song',
-                'body'   => array(
-                    'singerid'  => $id,
-                    'area_code' => 1,
-                    'page'      => 1,
-                    'plat'      => 0,
-                    'pagesize'  => $limit,
-                    'version'   => 8990,
-                ),
-                'format' => 'data.info',
-            );
-            break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://mobilecdn.kugou.com/api/v3/singer/song',
+                    'body'   => array(
+                        'singerid'  => $id,
+                        'area_code' => 1,
+                        'page'      => 1,
+                        'plat'      => 0,
+                        'pagesize'  => $limit,
+                        'version'   => 8990,
+                    ),
+                    'format' => 'data.info',
+                );
+                break;
             case 'baidu':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
-                'body'   => array(
-                    'from'     => 'qianqianmini',
-                    'method'   => 'baidu.ting.artist.getSongList',
-                    'artistid' => $id,
-                    'limits'   => $limit,
-                    'platform' => 'darwin',
-                    'offset'   => 0,
-                    'tinguid'  => 0,
-                    'version'  => '11.2.1',
-                ),
-                'format' => 'songlist',
-            );
-            break;
-			case 'kuwo':
-			$api = array(
-				'method' => 'GET',
-				'url'    => 'http://www.kuwo.cn/api/www/artist/artistMusic',
-				'body'   => array(
-					'artistid'    => $id,
-                    'pn'          => 1,
-                    'rn'          => $limit,
-					'httpsStatus' => 1,
-				),
-				'format' => 'data.list',
-			);
-			break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'body'   => array(
+                        'from'     => 'qianqianmini',
+                        'method'   => 'baidu.ting.artist.getSongList',
+                        'artistid' => $id,
+                        'limits'   => $limit,
+                        'platform' => 'darwin',
+                        'offset'   => 0,
+                        'tinguid'  => 0,
+                        'version'  => '11.2.1',
+                    ),
+                    'format' => 'songlist',
+                );
+                break;
+            case 'kuwo':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://www.kuwo.cn/api/www/artist/artistMusic',
+                    'body'   => array(
+                        'artistid'    => $id,
+                        'pn'          => 1,
+                        'rn'          => $limit,
+                        'httpsStatus' => 1,
+                    ),
+                    'format' => 'data.list',
+                );
+                break;
         }
 
         return $this->exec($api);
@@ -551,147 +552,146 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            $api = [
-                "method" => "POST",
-                "url" => "https://music.163.com/api/v6/playlist/detail",
-                "body" => [
-                    "id" => $id,
-                    "offset" => "0",
-                    "total" => "True",
-                    "limit" => "100000",
-                    "n" => "100000",
-                ],
-                "encode" => "netease_AESCBC",
-            ];
-            $playlistData = json_decode($this->exec($api), true);
-            $trackIds = $playlistData["playlist"]["trackIds"];
-            $allTracks = [];
-            $idBatches = array_chunk(array_column($trackIds, "id"), 500);
-
-            foreach ($idBatches as $batch) {
-                // Convert the batch into the proper format
-                $songIds = array_map(function ($id) {
-                    return ["id" => $id, "v" => 0]; // Using 'v' => 0 as per your suggestion
-                }, $batch);
-
-                // Fetch the song details for each batch
-                $songApi = [
+                $api = [
                     "method" => "POST",
-                    "url" => "https://music.163.com/api/v3/song/detail/",
+                    "url" => "https://music.163.com/api/v6/playlist/detail",
                     "body" => [
-                        "c" => json_encode($songIds),
+                        "id" => $id,
+                        "offset" => "0",
+                        "total" => "True",
+                        "limit" => "100000",
+                        "n" => "100000",
                     ],
                     "encode" => "netease_AESCBC",
                 ];
-                $songData = $this->exec($songApi);
-                // Merge songs data into allTracks
-                $allTracks = array_merge(
-                    $allTracks,
-                    json_decode($songData, true)["songs"]
-                );
-            }
-            $tmp = array_map(function ($data) {
-                $result = [
-                    "id" => $data["id"],
-                    "name" => $data["name"],
-                    "artist" => [],
-                    "album" => $data["al"]["name"],
-                    "pic_id" => isset($data["al"]["pic_str"])
-                        ? $data["al"]["pic_str"]
-                        : $data["al"]["pic"],
-                    "url_id" => $data["id"],
-                    "lyric_id" => $data["id"],
-                    "source" => "netease",
-                ];
-                if (isset($data["al"]["picUrl"])) {
-                    preg_match(
-                        "/\/(\d+)\./",
-                        $data["al"]["picUrl"],
-                        $match
+                $playlistData = json_decode($this->exec($api), true);
+                $trackIds = $playlistData["playlist"]["trackIds"];
+                $allTracks = [];
+                $idBatches = array_chunk(array_column($trackIds, "id"), 500);
+
+                foreach ($idBatches as $batch) {
+                    // Convert the batch into the proper format
+                    $songIds = array_map(function ($id) {
+                        return ["id" => $id, "v" => 0]; // Using 'v' => 0 as per your suggestion
+                    }, $batch);
+
+                    // Fetch the song details for each batch
+                    $songApi = [
+                        "method" => "POST",
+                        "url" => "https://music.163.com/api/v3/song/detail/",
+                        "body" => [
+                            "c" => json_encode($songIds),
+                        ],
+                        "encode" => "netease_AESCBC",
+                    ];
+                    $songData = $this->exec($songApi);
+                    // Merge songs data into allTracks
+                    $allTracks = array_merge(
+                        $allTracks,
+                        json_decode($songData, true)["songs"]
                     );
-                    $result["pic_id"] = $match[1];
                 }
-                foreach ($data["ar"] as $vo) {
-                    $result["artist"][] = $vo["name"];
-                }
-                return $result;
-            }, $allTracks);
-            return json_encode($tmp);
-            break;
+                $tmp = array_map(function ($data) {
+                    $result = [
+                        "id" => $data["id"],
+                        "name" => $data["name"],
+                        "artist" => [],
+                        "album" => $data["al"]["name"],
+                        "pic_id" => isset($data["al"]["pic_str"])
+                            ? $data["al"]["pic_str"]
+                            : $data["al"]["pic"],
+                        "url_id" => $data["id"],
+                        "lyric_id" => $data["id"],
+                        "source" => "netease",
+                    ];
+                    if (isset($data["al"]["picUrl"])) {
+                        preg_match(
+                            "/\/(\d+)\./",
+                            $data["al"]["picUrl"],
+                            $match
+                        );
+                        $result["pic_id"] = $match[1];
+                    }
+                    foreach ($data["ar"] as $vo) {
+                        $result["artist"][] = $vo["name"];
+                    }
+                    return $result;
+                }, $allTracks);
+                return json_encode($tmp);
             case 'tencent':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_v8_playlist_cp.fcg',
-                'body'   => array(
-                    'id'       => $id,
-                    'format'   => 'json',
-                    'newsong'  => 1,
-                    'platform' => 'jqspaframe.json',
-                ),
-                'format' => 'data.cdlist.0.songlist',
-            );
-            break;
-            case 'xiami':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.list.collectservice.getcollectdetail/1.0/',
-                'body'   => array(
-                    'data' => array(
-                        'listId'     => $id,
-                        'isFullTags' => false,
-                        'pagingVO'   => array(
-                            'page'     => 1,
-                            'pageSize' => 1000,
-                        ),
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_v8_playlist_cp.fcg',
+                    'body'   => array(
+                        'id'       => $id,
+                        'format'   => 'json',
+                        'newsong'  => 1,
+                        'platform' => 'jqspaframe.json',
                     ),
-                    'r' => 'mtop.alimusic.music.list.collectservice.getcollectdetail',
-                ),
-                'encode' => 'xiami_sign',
-                'format' => 'data.data.collectDetail.songs',
-            );
-            break;
+                    'format' => 'data.cdlist.0.songlist',
+                );
+                break;
+            case 'xiami':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.list.collectservice.getcollectdetail/1.0/',
+                    'body'   => array(
+                        'data' => array(
+                            'listId'     => $id,
+                            'isFullTags' => false,
+                            'pagingVO'   => array(
+                                'page'     => 1,
+                                'pageSize' => 1000,
+                            ),
+                        ),
+                        'r' => 'mtop.alimusic.music.list.collectservice.getcollectdetail',
+                    ),
+                    'encode' => 'xiami_sign',
+                    'format' => 'data.data.collectDetail.songs',
+                );
+                break;
             case 'kugou':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://mobilecdn.kugou.com/api/v3/special/song',
-                'body'   => array(
-                    'specialid' => $id,
-                    'area_code' => 1,
-                    'page'      => 1,
-                    'plat'      => 2,
-                    'pagesize'  => -1,
-                    'version'   => 8990,
-                ),
-                'format' => 'data.info',
-            );
-            break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://mobilecdn.kugou.com/api/v3/special/song',
+                    'body'   => array(
+                        'specialid' => $id,
+                        'area_code' => 1,
+                        'page'      => 1,
+                        'plat'      => 2,
+                        'pagesize'  => -1,
+                        'version'   => 8990,
+                    ),
+                    'format' => 'data.info',
+                );
+                break;
             case 'baidu':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
-                'body'   => array(
-                    'from'     => 'qianqianmini',
-                    'method'   => 'baidu.ting.diy.gedanInfo',
-                    'listid'   => $id,
-                    'platform' => 'darwin',
-                    'version'  => '11.2.1',
-                ),
-                'format' => 'content',
-            );
-            break;
-			case 'kuwo':
-			$api = array(
-				'method' => 'GET',
-				'url'    => 'http://www.kuwo.cn/api/www/playlist/playListInfo',
-				'body'   => array(
-					'pid'         => $id,
-                    'pn'          => 1,
-                    'rn'          => 1000,
-					'httpsStatus' => 1,
-				),
-				'format' => 'data.musicList',
-			);
-			break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'body'   => array(
+                        'from'     => 'qianqianmini',
+                        'method'   => 'baidu.ting.diy.gedanInfo',
+                        'listid'   => $id,
+                        'platform' => 'darwin',
+                        'version'  => '11.2.1',
+                    ),
+                    'format' => 'content',
+                );
+                break;
+            case 'kuwo':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://www.kuwo.cn/api/www/playlist/playListInfo',
+                    'body'   => array(
+                        'pid'         => $id,
+                        'pn'          => 1,
+                        'rn'          => 1000,
+                        'httpsStatus' => 1,
+                    ),
+                    'format' => 'data.musicList',
+                );
+                break;
         }
 
         return $this->exec($api);
@@ -701,100 +701,101 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            $api = array(
-                'method' => 'POST',
-                'url'    => 'https://music.163.com/api/song/enhance/player/url',
-                'body'   => array(
-                    'ids' => array($id),
-                    'br'  => $br * 999999,
-                ),
-                'encode' => 'netease_AESCBC',
-                'decode' => 'netease_url',
-            );
-            break;
-            case 'tencent':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_play_single_song.fcg',
-                'body'   => array(
-                    'songmid'  => $id,
-                    'platform' => 'yqq',
-                    'format'   => 'json',
-                ),
-                'decode' => 'tencent_url',
-            );
-            break;
-            case 'xiami':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.songservice.getsongs/1.0/',
-                'body'   => array(
-                    'data' => array(
-                        'songIds' => array(
-                            $id,
-                        ),
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'https://music.163.com/api/song/enhance/player/url',
+                    'body'   => array(
+                        'ids' => array($id),
+                        'br'  => $br * 999999,
                     ),
-                    'r' => 'mtop.alimusic.music.songservice.getsongs',
-                ),
-                'encode' => 'xiami_sign',
-                'decode' => 'xiami_url',
-            );
-            break;
+                    'encode' => 'netease_AESCBC',
+                    'decode' => 'netease_url',
+                );
+                break;
+            case 'tencent':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_play_single_song.fcg',
+                    'body'   => array(
+                        'songmid'  => $id,
+                        'platform' => 'yqq',
+                        'format'   => 'json',
+                    ),
+                    'decode' => 'tencent_url',
+                );
+                break;
+            case 'xiami':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.songservice.getsongs/1.0/',
+                    'body'   => array(
+                        'data' => array(
+                            'songIds' => array(
+                                $id,
+                            ),
+                        ),
+                        'r' => 'mtop.alimusic.music.songservice.getsongs',
+                    ),
+                    'encode' => 'xiami_sign',
+                    'decode' => 'xiami_url',
+                );
+                break;
             case 'kugou':
-            $api = array(
-                'method' => 'POST',
-                'url'    => 'http://media.store.kugou.com/v1/get_res_privilege',
-                'body'   => json_encode(
-                    array(
-                    'relate'    => 1,
-                    'userid'    => '0',
-                    'vip'       => 0,
-                    'appid'     => 1000,
-                    'token'     => '',
-                    'behavior'  => 'download',
-                    'area_code' => '1',
-                    'clientver' => '8990',
-                    'resource'  => array(array(
-                        'id'   => 0,
-                        'type' => 'audio',
-                        'hash' => $id,
-                    )), )
-                ),
-                'decode' => 'kugou_url',
-            );
-            break;
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'http://media.store.kugou.com/v1/get_res_privilege',
+                    'body'   => json_encode(
+                        array(
+                            'relate'    => 1,
+                            'userid'    => '0',
+                            'vip'       => 0,
+                            'appid'     => 1000,
+                            'token'     => '',
+                            'behavior'  => 'download',
+                            'area_code' => '1',
+                            'clientver' => '8990',
+                            'resource'  => array(array(
+                                'id'   => 0,
+                                'type' => 'audio',
+                                'hash' => $id,
+                            )),
+                        )
+                    ),
+                    'decode' => 'kugou_url',
+                );
+                break;
             case 'baidu':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
-                'body'   => array(
-                    'from'     => 'qianqianmini',
-                    'method'   => 'baidu.ting.song.getInfos',
-                    'songid'   => $id,
-                    'res'      => 1,
-                    'platform' => 'darwin',
-                    'version'  => '1.0.0',
-                ),
-                'encode' => 'baidu_AESCBC',
-                'decode' => 'baidu_url',
-            );
-            break;
-			case 'kuwo':
-			$api = array(
-				'method' => 'GET',
-				'url'    => 'http://www.kuwo.cn/url',
-				'body'   => array(
-					'rid'         => $id,
-					'response'    => 'url',
-					'type'        => 'convert_url3',
-					'br'          => '128kmp3',
-					'from'        => 'web',
-					't'           => time(),
-					'httpsStatus' => 1,
-				),
-				'decode' => 'kuwo_url',
-			);
-			break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'body'   => array(
+                        'from'     => 'qianqianmini',
+                        'method'   => 'baidu.ting.song.getInfos',
+                        'songid'   => $id,
+                        'res'      => 1,
+                        'platform' => 'darwin',
+                        'version'  => '1.0.0',
+                    ),
+                    'encode' => 'baidu_AESCBC',
+                    'decode' => 'baidu_url',
+                );
+                break;
+            case 'kuwo':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://www.kuwo.cn/url',
+                    'body'   => array(
+                        'rid'         => $id,
+                        'response'    => 'url',
+                        'type'        => 'convert_url3',
+                        'br'          => '128kmp3',
+                        'from'        => 'web',
+                        't'           => time(),
+                        'httpsStatus' => 1,
+                    ),
+                    'decode' => 'kuwo_url',
+                );
+                break;
         }
         $this->temp['br'] = $br;
 
@@ -805,43 +806,42 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            $api = array(
-                'method' => 'POST',
-                'url'    => 'https://music.163.com/api/song/lyric',
-                'body'   => array(
-                    'id'        => $id,
-                    'os'        => 'pc',
-                    'lv'        => -1,
-                    'kv'        => -1,
-                    'tv'        => -1,
-                    'rv'        => -1,
-                    'yv'        => 1,
-                    'showRole'  => 'False',
-                    'cp'        => 'False',
-                    'e_r'       => 'False',
-                ),
-                'encode' => 'netease_AESCBC',
-            );
-            // 发送请求，获取结果
-            $result = $this->exec($api);
-            $tmp = json_decode($result, true);
-            // 手动处理返回结果
-            if (isset($tmp['yrc'])) {
-                // 如果存在 yrc 字段，进一步判断 yrc 参数的值
-                if ($this->yrc) {
-                    // yrc 参数为 true，手动处理 netease_lyric_yrc 解析
-                    $decoded_result = $this->netease_lyric_yrc($result);
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'https://music.163.com/api/song/lyric',
+                    'body'   => array(
+                        'id'        => $id,
+                        'os'        => 'pc',
+                        'lv'        => -1,
+                        'kv'        => -1,
+                        'tv'        => -1,
+                        'rv'        => -1,
+                        'yv'        => 1,
+                        'showRole'  => 'False',
+                        'cp'        => 'False',
+                        'e_r'       => 'False',
+                    ),
+                    'encode' => 'netease_AESCBC',
+                );
+                // 发送请求，获取结果
+                $result = $this->exec($api);
+                $tmp = json_decode($result, true);
+                // 手动处理返回结果
+                if (isset($tmp['yrc'])) {
+                    // 如果存在 yrc 字段，进一步判断 yrc 参数的值
+                    if ($this->yrc) {
+                        // yrc 参数为 true，手动处理 netease_lyric_yrc 解析
+                        $decoded_result = $this->netease_lyric_yrc($result);
+                    } else {
+                        // yrc 参数为 false，手动处理普通 netease_lyric 解析
+                        $decoded_result = $this->netease_lyric($result);
+                    }
                 } else {
-                    // yrc 参数为 false，手动处理普通 netease_lyric 解析
+                    // 不存在 yrc 字段，直接执行普通 netease_lyric 解析
                     $decoded_result = $this->netease_lyric($result);
                 }
-            } else {
-                // 不存在 yrc 字段，直接执行普通 netease_lyric 解析
-                $decoded_result = $this->netease_lyric($result);
-            }
-            // 返回最终处理后的结果
-            return $decoded_result;
-            break;
+                // 返回最终处理后的结果
+                return $decoded_result;
 
             case 'tencent':
                 $api = array(
@@ -920,41 +920,41 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            $url = 'https://p3.music.126.net/'.$this->netease_encryptId($id).'/'.$id.'.jpg?param=';
-            break;
+                $url = 'https://p3.music.126.net/' . $this->netease_encryptId($id) . '/' . $id . '.jpg?param=';
+                break;
             case 'tencent':
-            $url = 'https://y.gtimg.cn/music/photo_new/T002R'.$size.'x'.$size.'M000'.$id.'.jpg?max_age=2592000';
-            break;
+                $url = 'https://y.gtimg.cn/music/photo_new/T002R' . $size . 'x' . $size . 'M000' . $id . '.jpg?max_age=2592000';
+                break;
             case 'xiami':
-            $format = $this->format;
-            $data = $this->format(false)->song($id);
-            $this->format = $format;
-            $data = json_decode($data, true);
-            $url = $data['data']['data']['songDetail']['albumLogo'];
-            $url = str_replace('http:', 'https:', $url).'@1e_1c_100Q_'.$size.'h_'.$size.'w';
-            break;
+                $format = $this->format;
+                $data = $this->format(false)->song($id);
+                $this->format = $format;
+                $data = json_decode($data, true);
+                $url = $data['data']['data']['songDetail']['albumLogo'];
+                $url = str_replace('http:', 'https:', $url) . '@1e_1c_100Q_' . $size . 'h_' . $size . 'w';
+                break;
             case 'kugou':
-            $format = $this->format;
-            $data = $this->format(false)->song($id);
-            $this->format = $format;
-            $data = json_decode($data, true);
-            $url = $data['imgUrl'];
-            $url = str_replace('{size}', '400', $url);
-            break;
+                $format = $this->format;
+                $data = $this->format(false)->song($id);
+                $this->format = $format;
+                $data = json_decode($data, true);
+                $url = $data['imgUrl'];
+                $url = str_replace('{size}', '400', $url);
+                break;
             case 'baidu':
-            $format = $this->format;
-            $data = $this->format(false)->song($id);
-            $this->format = $format;
-            $data = json_decode($data, true);
-            $url = isset($data['songinfo']['pic_radio']) ? $data['songinfo']['pic_radio'] : $data['songinfo']['pic_small'];
-            break;
-			case 'kuwo':
-			$format = $this->format;
-            $data = $this->format(false)->song($id);
-            $this->format = $format;
-            $data = json_decode($data, true);
-			$url = isset($data['data']['pic']) ? $data['data']['pic'] : $data['data']['albumpic'];
-			break;
+                $format = $this->format;
+                $data = $this->format(false)->song($id);
+                $this->format = $format;
+                $data = json_decode($data, true);
+                $url = isset($data['songinfo']['pic_radio']) ? $data['songinfo']['pic_radio'] : $data['songinfo']['pic_small'];
+                break;
+            case 'kuwo':
+                $format = $this->format;
+                $data = $this->format(false)->song($id);
+                $this->format = $format;
+                $data = json_decode($data, true);
+                $url = isset($data['data']['pic']) ? $data['data']['pic'] : $data['data']['albumpic'];
+                break;
         }
 
         return json_encode(array('url' => $url));
@@ -964,55 +964,55 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            return array(
-                'Referer'         => 'https://music.163.com/',
-                'Cookie'          => 'appver=8.2.30; os=iPhone OS; osver=15.0; EVNSM=1.0.0; buildver=2206; channel=distribution; machineid=iPhone13.3',
-                'User-Agent'      => 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 CloudMusic/0.1.1 NeteaseMusic/8.2.30',
-                'X-Real-IP'       => long2ip(mt_rand(1884815360, 1884890111)),
-                'Accept'          => '*/*',
-                'Accept-Language' => 'zh-CN,zh;q=0.8,gl;q=0.6,zh-TW;q=0.4',
-                'Connection'      => 'keep-alive',
-                'Content-Type'    => 'application/x-www-form-urlencoded',
-            );
+                return array(
+                    'Referer'         => 'https://music.163.com/',
+                    'Cookie'          => 'appver=8.2.30; os=iPhone OS; osver=15.0; EVNSM=1.0.0; buildver=2206; channel=distribution; machineid=iPhone13.3',
+                    'User-Agent'      => 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 CloudMusic/0.1.1 NeteaseMusic/8.2.30',
+                    'X-Real-IP'       => long2ip(mt_rand(1884815360, 1884890111)),
+                    'Accept'          => '*/*',
+                    'Accept-Language' => 'zh-CN,zh;q=0.8,gl;q=0.6,zh-TW;q=0.4',
+                    'Connection'      => 'keep-alive',
+                    'Content-Type'    => 'application/x-www-form-urlencoded',
+                );
             case 'tencent':
-            return array(
-                'Referer'         => 'http://y.qq.com',
-                'Cookie'          => 'pgv_pvi=22038528; pgv_si=s3156287488; pgv_pvid=5535248600; yplayer_open=1; ts_last=y.qq.com/portal/player.html; ts_uid=4847550686; yq_index=0; qqmusic_fromtag=66; player_exist=1',
-                'User-Agent'      => 'QQ%E9%9F%B3%E4%B9%90/54409 CFNetwork/901.1 Darwin/17.6.0 (x86_64)',
-                'Accept'          => '*/*',
-                'Accept-Language' => 'zh-CN,zh;q=0.8,gl;q=0.6,zh-TW;q=0.4',
-                'Connection'      => 'keep-alive',
-                'Content-Type'    => 'application/x-www-form-urlencoded',
-            );
+                return array(
+                    'Referer'         => 'http://y.qq.com',
+                    'Cookie'          => 'pgv_pvi=22038528; pgv_si=s3156287488; pgv_pvid=5535248600; yplayer_open=1; ts_last=y.qq.com/portal/player.html; ts_uid=4847550686; yq_index=0; qqmusic_fromtag=66; player_exist=1',
+                    'User-Agent'      => 'QQ%E9%9F%B3%E4%B9%90/54409 CFNetwork/901.1 Darwin/17.6.0 (x86_64)',
+                    'Accept'          => '*/*',
+                    'Accept-Language' => 'zh-CN,zh;q=0.8,gl;q=0.6,zh-TW;q=0.4',
+                    'Connection'      => 'keep-alive',
+                    'Content-Type'    => 'application/x-www-form-urlencoded',
+                );
             case 'xiami':
-            return array(
-                'Cookie'          => '_m_h5_tk=15d3402511a022796d88b249f83fb968_1511163656929; _m_h5_tk_enc=b6b3e64d81dae577fc314b5c5692df3c',
-                'User-Agent'      => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/537.36 (KHTML, like Gecko) XIAMI-MUSIC/3.1.1 Chrome/56.0.2924.87 Electron/1.6.11 Safari/537.36',
-                'Accept'          => 'application/json',
-                'Content-type'    => 'application/x-www-form-urlencoded',
-                'Accept-Language' => 'zh-CN',
-            );
+                return array(
+                    'Cookie'          => '_m_h5_tk=15d3402511a022796d88b249f83fb968_1511163656929; _m_h5_tk_enc=b6b3e64d81dae577fc314b5c5692df3c',
+                    'User-Agent'      => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/537.36 (KHTML, like Gecko) XIAMI-MUSIC/3.1.1 Chrome/56.0.2924.87 Electron/1.6.11 Safari/537.36',
+                    'Accept'          => 'application/json',
+                    'Content-type'    => 'application/x-www-form-urlencoded',
+                    'Accept-Language' => 'zh-CN',
+                );
             case 'kugou':
-            return array(
-                'User-Agent'      => 'IPhone-8990-searchSong',
-                'UNI-UserAgent'   => 'iOS11.4-Phone8990-1009-0-WiFi',
-            );
+                return array(
+                    'User-Agent'      => 'IPhone-8990-searchSong',
+                    'UNI-UserAgent'   => 'iOS11.4-Phone8990-1009-0-WiFi',
+                );
             case 'baidu':
-            return array(
-                'Cookie'          => 'BAIDUID='.$this->getRandomHex(32).':FG=1',
-                'User-Agent'      => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) baidu-music/1.2.1 Chrome/66.0.3359.181 Electron/3.0.5 Safari/537.36',
-                'Accept'          => '*/*',
-                'Content-type'    => 'application/json;charset=UTF-8',
-                'Accept-Language' => 'zh-CN',
-            );
-			case 'kuwo':
-            return array(
-				'Cookie'		  => 'Hm_lvt_cdb524f42f0ce19b169a8071123a4797=1623339177,1623339183; _ga=GA1.2.1195980605.1579367081; Hm_lpvt_cdb524f42f0ce19b169a8071123a4797=1623339982; kw_token=3E7JFQ7MRPL; _gid=GA1.2.747985028.1623339179; _gat=1',
-                'csrf'            => '3E7JFQ7MRPL',
-				'Host'            => 'www.kuwo.cn',
-				'Referer'         => 'http://www.kuwo.cn/',
-				'User-Agent'      => 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36',
-            );
+                return array(
+                    'Cookie'          => 'BAIDUID=' . $this->getRandomHex(32) . ':FG=1',
+                    'User-Agent'      => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) baidu-music/1.2.1 Chrome/66.0.3359.181 Electron/3.0.5 Safari/537.36',
+                    'Accept'          => '*/*',
+                    'Content-type'    => 'application/json;charset=UTF-8',
+                    'Accept-Language' => 'zh-CN',
+                );
+            case 'kuwo':
+                return array(
+                    'Cookie'          => 'Hm_lvt_cdb524f42f0ce19b169a8071123a4797=1623339177,1623339183; _ga=GA1.2.1195980605.1579367081; Hm_lpvt_cdb524f42f0ce19b169a8071123a4797=1623339982; kw_token=3E7JFQ7MRPL; _gid=GA1.2.747985028.1623339179; _gat=1',
+                    'csrf'            => '3E7JFQ7MRPL',
+                    'Host'            => 'www.kuwo.cn',
+                    'Referer'         => 'http://www.kuwo.cn/',
+                    'User-Agent'      => 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36',
+                );
         }
     }
 
@@ -1020,9 +1020,6 @@ class Meting
     {
         if (function_exists('random_bytes')) {
             return bin2hex(random_bytes($length / 2));
-        }
-        if (function_exists('mcrypt_create_iv')) {
-            return bin2hex(mcrypt_create_iv($length / 2, MCRYPT_DEV_URANDOM));
         }
         if (function_exists('openssl_random_pseudo_bytes')) {
             return bin2hex(openssl_random_pseudo_bytes($length / 2));
@@ -1045,7 +1042,7 @@ class Meting
         $hex = '';
         do {
             $last = bcmod($dec, 16);
-            $hex = dechex($last).$hex;
+            $hex = dechex($last) . $hex;
             $dec = bcdiv(bcsub($dec, $last), 16);
         } while ($dec > 0);
 
@@ -1058,7 +1055,7 @@ class Meting
         for ($i = 0; $i < strlen($string); $i++) {
             $ord = ord($string[$i]);
             $hexCode = dechex($ord);
-            $hex .= substr('0'.$hexCode, -2);
+            $hex .= substr('0' . $hexCode, -2);
         }
 
         return $hex;
@@ -1080,14 +1077,18 @@ class Meting
         $body = json_encode($api['body']);
 
         if (function_exists('openssl_encrypt')) {
-            $body = openssl_encrypt($body, 'aes-128-cbc', $nonce, false, $vi);
-            $body = openssl_encrypt($body, 'aes-128-cbc', $skey, false, $vi);
-        } else {
+            // 使用 openssl_encrypt 进行加密
             $pad = 16 - (strlen($body) % 16);
-            $body = base64_encode(mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $nonce, $body.str_repeat(chr($pad), $pad), MCRYPT_MODE_CBC, $vi));
+            $body = $body . str_repeat(chr($pad), $pad);
+            $body = openssl_encrypt($body, 'aes-128-cbc', $nonce, OPENSSL_RAW_DATA, $vi);
+            $body = base64_encode($body);
+
             $pad = 16 - (strlen($body) % 16);
-            $body = base64_encode(mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $skey, $body.str_repeat(chr($pad), $pad), MCRYPT_MODE_CBC, $vi));
+            $body = $body . str_repeat(chr($pad), $pad);
+            $body = openssl_encrypt($body, 'aes-128-cbc', $skey, OPENSSL_RAW_DATA, $vi);
+            $body = base64_encode($body);
         }
+
 
         if (extension_loaded('bcmath')) {
             $skey = strrev(mb_convert_encoding($skey, 'UTF-8', 'ISO-8859-1'));
@@ -1113,14 +1114,16 @@ class Meting
         $key = 'DBEECF8C50FD160E';
         $vi = '1231021386755796';
 
-        $data = 'songid='.$api['body']['songid'].'&ts='.intval(microtime(true) * 1000);
+        $data = 'songid=' . $api['body']['songid'] . '&ts=' . intval(microtime(true) * 1000);
 
         if (function_exists('openssl_encrypt')) {
-            $data = openssl_encrypt($data, 'aes-128-cbc', $key, false, $vi);
-        } else {
+            // 为了确保数据长度是 16 的倍数，先进行填充
             $pad = 16 - (strlen($data) % 16);
-            $data = base64_encode(mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $key, $data.str_repeat(chr($pad), $pad), MCRYPT_MODE_CBC, $vi));
+            $data = $data . str_repeat(chr($pad), $pad);  // 填充
+            $data = openssl_encrypt($data, 'aes-128-cbc', $key, OPENSSL_RAW_DATA, $vi);
+            $data = base64_encode($data);  // 加密后进行 base64 编码
         }
+
 
         $api['body']['e'] = $data;
 
@@ -1131,7 +1134,7 @@ class Meting
     {
         $data = $this->curl('https://acs.m.xiami.com/h5/mtop.alimusic.recommend.songservice.getdailysongs/1.0/?appKey=12574478&t=1560663823000&dataType=json&data=%7B%22requestStr%22%3A%22%7B%5C%22header%5C%22%3A%7B%5C%22platformId%5C%22%3A%5C%22mac%5C%22%7D%2C%5C%22model%5C%22%3A%5B%5D%7D%22%7D&api=mtop.alimusic.recommend.songservice.getdailysongs&v=1.0&type=originaljson&sign=22ad1377ee193f3e2772c17c6192b17c', null, 1);
         preg_match_all('/_m_h5[^;]+/', $data->raw, $match);
-        $this->header['Cookie'] = $match[0][0].'; '.$match[0][1];
+        $this->header['Cookie'] = $match[0][0] . '; ' . $match[0][1];
         $data = json_encode(array(
             'requestStr' => json_encode(array(
                 'header' => array(
@@ -1235,7 +1238,7 @@ class Meting
 
         foreach ($type as $vo) {
             $payload['req_0']['param']['songmid'][] = $data['data'][0]['mid'];
-            $payload['req_0']['param']['filename'][] = $vo[2].$data['data'][0]['file']['media_mid'].'.'.$vo[3];
+            $payload['req_0']['param']['filename'][] = $vo[2] . $data['data'][0]['file']['media_mid'] . '.' . $vo[3];
             $payload['req_0']['param']['songtype'][] = $data['data'][0]['type'];
         }
 
@@ -1256,7 +1259,7 @@ class Meting
             if ($data['data'][0]['file'][$vo[0]] && $vo[1] <= $this->temp['br']) {
                 if (!empty($vkeys[$index]['vkey'])) {
                     $url = array(
-                        'url'  => $response['req_0']['data']['sip'][0].$vkeys[$index]['purl'],
+                        'url'  => $response['req_0']['data']['sip'][0] . $vkeys[$index]['purl'],
                         'size' => $data['data'][0]['file'][$vo[0]],
                         'br'   => $vo[1],
                     );
@@ -1322,7 +1325,7 @@ class Meting
                     'url'    => 'http://trackercdn.kugou.com/i/v2/',
                     'body'   => array(
                         'hash'     => $vo['hash'],
-                        'key'      => md5($vo['hash'].'kgcloudv2'),
+                        'key'      => md5($vo['hash'] . 'kgcloudv2'),
                         'pid'      => 3,
                         'behavior' => 'play',
                         'cmd'      => '25',
@@ -1375,7 +1378,7 @@ class Meting
         return json_encode($url);
     }
 
-	private function kuwo_url($result)
+    private function kuwo_url($result)
     {
         $data = json_decode($result, true);
 
@@ -1447,8 +1450,8 @@ class Meting
             preg_match_all('/\[([\d:\.]+)\](.*)\s\[x-trans\](.*)/i', $data, $match);
             if (count($match[0])) {
                 for ($i = 0; $i < count($match[0]); $i++) {
-                    $A[] = '['.$match[1][$i].']'.$match[2][$i];
-                    $B[] = '['.$match[1][$i].']'.$match[3][$i];
+                    $A[] = '[' . $match[1][$i] . ']' . $match[2][$i];
+                    $B[] = '[' . $match[1][$i] . ']' . $match[3][$i];
                 }
                 $arr = array(
                     'lyric'  => str_replace($match[0], $A, $data),
@@ -1505,30 +1508,30 @@ class Meting
         return json_encode($data, JSON_UNESCAPED_UNICODE);
     }
 
-	private function kuwo_lyric($result)
+    private function kuwo_lyric($result)
     {
         $result = json_decode($result, true);
         if (count($result['data']['lrclist'])) {
-			$kuwolrc = '';
-			for ($i = 0; $i < count($result['data']['lrclist']); $i++) {
-				$otime = $result['data']['lrclist'][$i]['time'];
-				$osec = explode('.', $otime)[0];
-				$min = str_pad(floor($osec / 60), 2, "0", STR_PAD_LEFT);
-				$sec = str_pad($osec - $min * 60, 2, "0", STR_PAD_LEFT);
-				$msec = explode('.', $otime)[1];
-				$olyric = $result['data']['lrclist'][$i]['lineLyric'];
-				$kuwolrc = $kuwolrc . '[' . $min . ':' . $sec . '.' . $msec . ']' . $olyric . "\n";
-			}
-			$arr = array(
-				'lyric'  => $kuwolrc,
-				'tlyric' => '',
-			);
+            $kuwolrc = '';
+            for ($i = 0; $i < count($result['data']['lrclist']); $i++) {
+                $otime = $result['data']['lrclist'][$i]['time'];
+                $osec = explode('.', $otime)[0];
+                $min = str_pad(floor($osec / 60), 2, "0", STR_PAD_LEFT);
+                $sec = str_pad($osec - $min * 60, 2, "0", STR_PAD_LEFT);
+                $msec = explode('.', $otime)[1];
+                $olyric = $result['data']['lrclist'][$i]['lineLyric'];
+                $kuwolrc = $kuwolrc . '[' . $min . ':' . $sec . '.' . $msec . ']' . $olyric . "\n";
+            }
+            $arr = array(
+                'lyric'  => $kuwolrc,
+                'tlyric' => '',
+            );
         } else {
-			$arr = array(
+            $arr = array(
                 'lyric'  => '',
                 'tlyric' => '',
             );
-		}
+        }
         return json_encode($arr, JSON_UNESCAPED_UNICODE);
     }
 
@@ -1608,11 +1611,31 @@ class Meting
             'lyric_id' => $data['hash'],
             'source'   => 'kugou',
         );
-        list($result['artist'], $result['name']) = explode(' - ', $result['name'], 2);
-        $result['artist'] = explode('、', $result['artist']);
+
+        // 确保 'name' 是字符串类型并包含 ' - '
+        if (is_string($result['name']) && strpos($result['name'], ' - ') !== false) {
+            list($result['artist'], $result['name']) = explode(' - ', $result['name'], 2);
+        } else {
+            // 如果 'name' 中没有 ' - '，将 artist 设置为默认空数组
+            $result['artist'] = [];
+        }
+
+        // 如果 'artist' 是数组类型，不应该传递给 explode 函数
+        if (is_array($result['artist'])) {
+            // 如果 'artist' 已经是数组，跳过 explode 操作
+            $result['artist'] = implode('、', $result['artist']);
+        }
+
+        // 只有当 artist 是字符串时才使用 explode
+        if (is_string($result['artist'])) {
+            $result['artist'] = explode('、', $result['artist']);
+        }
 
         return $result;
     }
+
+
+
 
     protected function format_baidu($data)
     {
@@ -1630,7 +1653,7 @@ class Meting
         return $result;
     }
 
-	protected function format_kuwo($data)
+    protected function format_kuwo($data)
     {
         $result = array(
             'id'       => $data['rid'],
@@ -1645,5 +1668,4 @@ class Meting
 
         return $result;
     }
-
 }

--- a/src/Meting.php
+++ b/src/Meting.php
@@ -219,7 +219,7 @@ class Meting
             case 'kugou':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://mobilecdn.kugou.com/api/v3/search/song',
+                    'url'    => 'https://mobilecdn.kugou.com/api/v3/search/song',
                     'body'   => array(
                         'api_ver'   => 1,
                         'area_code' => 1,
@@ -239,7 +239,7 @@ class Meting
             case 'baidu':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'url'    => 'https://musicapi.taihe.com/v1/restserver/ting',
                     'body'   => array(
                         'from'      => 'qianqianmini',
                         'method'    => 'baidu.ting.search.merge',
@@ -256,7 +256,7 @@ class Meting
             case 'kuwo':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://www.kuwo.cn/api/www/search/searchMusicBykeyWord',
+                    'url'    => 'https://www.kuwo.cn/api/www/search/searchMusicBykeyWord',
                     'body'   => array(
                         'key'         => $keyword,
                         'pn'          => isset($option['page']) ? $option['page'] : 1,
@@ -314,7 +314,7 @@ class Meting
             case 'kugou':
                 $api = array(
                     'method' => 'POST',
-                    'url'    => 'http://m.kugou.com/app/i/getSongInfo.php',
+                    'url'    => 'https://m.kugou.com/app/i/getSongInfo.php',
                     'body'   => array(
                         'cmd'  => 'playInfo',
                         'hash' => $id,
@@ -326,7 +326,7 @@ class Meting
             case 'baidu':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'url'    => 'https://musicapi.taihe.com/v1/restserver/ting',
                     'body'   => array(
                         'from'     => 'qianqianmini',
                         'method'   => 'baidu.ting.song.getInfos',
@@ -342,7 +342,7 @@ class Meting
             case 'kuwo':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://www.kuwo.cn/api/www/music/musicInfo',
+                    'url'    => 'https://www.kuwo.cn/api/www/music/musicInfo',
                     'body'   => array(
                         'mid'         => $id,
                         'httpsStatus' => 1,
@@ -404,7 +404,7 @@ class Meting
             case 'kugou':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://mobilecdn.kugou.com/api/v3/album/song',
+                    'url'    => 'https://mobilecdn.kugou.com/api/v3/album/song',
                     'body'   => array(
                         'albumid'   => $id,
                         'area_code' => 1,
@@ -419,7 +419,7 @@ class Meting
             case 'baidu':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'url'    => 'https://musicapi.taihe.com/v1/restserver/ting',
                     'body'   => array(
                         'from'     => 'qianqianmini',
                         'method'   => 'baidu.ting.album.getAlbumInfo',
@@ -433,7 +433,7 @@ class Meting
             case 'kuwo':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://www.kuwo.cn/api/www/album/albumInfo',
+                    'url'    => 'https://www.kuwo.cn/api/www/album/albumInfo',
                     'body'   => array(
                         'albumId'     => $id,
                         'pn'          => 1,
@@ -501,7 +501,7 @@ class Meting
             case 'kugou':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://mobilecdn.kugou.com/api/v3/singer/song',
+                    'url'    => 'https://mobilecdn.kugou.com/api/v3/singer/song',
                     'body'   => array(
                         'singerid'  => $id,
                         'area_code' => 1,
@@ -516,7 +516,7 @@ class Meting
             case 'baidu':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'url'    => 'https://musicapi.taihe.com/v1/restserver/ting',
                     'body'   => array(
                         'from'     => 'qianqianmini',
                         'method'   => 'baidu.ting.artist.getSongList',
@@ -533,7 +533,7 @@ class Meting
             case 'kuwo':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://www.kuwo.cn/api/www/artist/artistMusic',
+                    'url'    => 'https://www.kuwo.cn/api/www/artist/artistMusic',
                     'body'   => array(
                         'artistid'    => $id,
                         'pn'          => 1,
@@ -653,7 +653,7 @@ class Meting
             case 'kugou':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://mobilecdn.kugou.com/api/v3/special/song',
+                    'url'    => 'https://mobilecdn.kugou.com/api/v3/special/song',
                     'body'   => array(
                         'specialid' => $id,
                         'area_code' => 1,
@@ -668,7 +668,7 @@ class Meting
             case 'baidu':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'url'    => 'https://musicapi.taihe.com/v1/restserver/ting',
                     'body'   => array(
                         'from'     => 'qianqianmini',
                         'method'   => 'baidu.ting.diy.gedanInfo',
@@ -682,7 +682,7 @@ class Meting
             case 'kuwo':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://www.kuwo.cn/api/www/playlist/playListInfo',
+                    'url'    => 'https://www.kuwo.cn/api/www/playlist/playListInfo',
                     'body'   => array(
                         'pid'         => $id,
                         'pn'          => 1,
@@ -743,7 +743,7 @@ class Meting
             case 'kugou':
                 $api = array(
                     'method' => 'POST',
-                    'url'    => 'http://media.store.kugou.com/v1/get_res_privilege',
+                    'url'    => 'https://media.store.kugou.com/v1/get_res_privilege',
                     'body'   => json_encode(
                         array(
                             'relate'    => 1,
@@ -767,7 +767,7 @@ class Meting
             case 'baidu':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'url'    => 'https://musicapi.taihe.com/v1/restserver/ting',
                     'body'   => array(
                         'from'     => 'qianqianmini',
                         'method'   => 'baidu.ting.song.getInfos',
@@ -783,7 +783,7 @@ class Meting
             case 'kuwo':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://www.kuwo.cn/url',
+                    'url'    => 'https://www.kuwo.cn/url',
                     'body'   => array(
                         'rid'         => $id,
                         'response'    => 'url',
@@ -873,7 +873,7 @@ class Meting
             case 'kugou':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://krcs.kugou.com/search',
+                    'url'    => 'https://krcs.kugou.com/search',
                     'body'   => array(
                         'keyword'  => '%20-%20',
                         'ver'      => 1,
@@ -888,7 +888,7 @@ class Meting
             case 'baidu':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'url'    => 'https://musicapi.taihe.com/v1/restserver/ting',
                     'body'   => array(
                         'from'     => 'qianqianmini',
                         'method'   => 'baidu.ting.song.lry',
@@ -903,7 +903,7 @@ class Meting
             case 'kuwo':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://m.kuwo.cn/newh5/singles/songinfoandlrc',
+                    'url'    => 'https://m.kuwo.cn/newh5/singles/songinfoandlrc',
                     'body'   => array(
                         'musicId'     => $id,
                         'httpsStatus' => 1,
@@ -976,7 +976,7 @@ class Meting
                 );
             case 'tencent':
                 return array(
-                    'Referer'         => 'http://y.qq.com',
+                    'Referer'         => 'https://y.qq.com',
                     'Cookie'          => 'pgv_pvi=22038528; pgv_si=s3156287488; pgv_pvid=5535248600; yplayer_open=1; ts_last=y.qq.com/portal/player.html; ts_uid=4847550686; yq_index=0; qqmusic_fromtag=66; player_exist=1',
                     'User-Agent'      => 'QQ%E9%9F%B3%E4%B9%90/54409 CFNetwork/901.1 Darwin/17.6.0 (x86_64)',
                     'Accept'          => '*/*',
@@ -1010,7 +1010,7 @@ class Meting
                     'Cookie'          => 'Hm_lvt_cdb524f42f0ce19b169a8071123a4797=1623339177,1623339183; _ga=GA1.2.1195980605.1579367081; Hm_lpvt_cdb524f42f0ce19b169a8071123a4797=1623339982; kw_token=3E7JFQ7MRPL; _gid=GA1.2.747985028.1623339179; _gat=1',
                     'csrf'            => '3E7JFQ7MRPL',
                     'Host'            => 'www.kuwo.cn',
-                    'Referer'         => 'http://www.kuwo.cn/',
+                    'Referer'         => 'https://www.kuwo.cn/',
                     'User-Agent'      => 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36',
                 );
         }
@@ -1322,7 +1322,7 @@ class Meting
             if ($vo['info']['bitrate'] <= $this->temp['br'] && $vo['info']['bitrate'] > $max) {
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://trackercdn.kugou.com/i/v2/',
+                    'url'    => 'https://trackercdn.kugou.com/i/v2/',
                     'body'   => array(
                         'hash'     => $vo['hash'],
                         'key'      => md5($vo['hash'] . 'kgcloudv2'),
@@ -1478,7 +1478,7 @@ class Meting
         $result = json_decode($result, true);
         $api = array(
             'method' => 'GET',
-            'url'    => 'http://lyrics.kugou.com/download',
+            'url'    => 'https://lyrics.kugou.com/download',
             'body'   => array(
                 'charset'   => 'utf8',
                 'accesskey' => $result['candidates'][0]['accesskey'],

--- a/src/Meting.php
+++ b/src/Meting.php
@@ -697,7 +697,7 @@ class Meting
         return $this->exec($api);
     }
 
-    public function url($id, $br = 320)
+    public function url($id, $br = 2147483)
     {
         switch ($this->server) {
             case 'netease':
@@ -706,7 +706,7 @@ class Meting
                     'url'    => 'https://music.163.com/api/song/enhance/player/url',
                     'body'   => array(
                         'ids' => array($id),
-                        'br'  => $br * 999999,
+                        'br'  => $br * 1000,
                     ),
                     'encode' => 'netease_AESCBC',
                     'decode' => 'netease_url',
@@ -916,16 +916,27 @@ class Meting
         return $this->exec($api);
     }
 
-    public function pic($id, $size = 300)
+    public function pic($id, $size)
     {
         switch ($this->server) {
             case 'netease':
-                $url = 'https://p3.music.126.net/' . $this->netease_encryptId($id) . '/' . $id . '.jpg?param=';
+                if (isset($size) && !empty($size)) {
+                    $url = 'https://p3.music.126.net/' . $this->netease_encryptId($id) . '/' . $id . '.jpg?param=' . $size . 'x' . $size;
+                } else {
+                    $url = 'https://p3.music.126.net/' . $this->netease_encryptId($id) . '/' . $id . '.jpg';
+                };
                 break;
             case 'tencent':
-                $url = 'https://y.gtimg.cn/music/photo_new/T002R' . $size . 'x' . $size . 'M000' . $id . '.jpg?max_age=2592000';
+                if (isset($size) && !empty($size)) {
+                    $url = 'https://y.gtimg.cn/music/photo_new/T002R' . $size . 'x' . $size . 'M000' . $id . '.jpg';
+                } else {
+                    $url = 'https://y.gtimg.cn/music/photo_new/T002M000' . $id . '.jpg';
+                };
                 break;
             case 'xiami':
+                if (!isset($size) || empty($size)) {
+                    $size = 300;
+                };
                 $format = $this->format;
                 $data = $this->format(false)->song($id);
                 $this->format = $format;
@@ -934,6 +945,9 @@ class Meting
                 $url = str_replace('http:', 'https:', $url) . '@1e_1c_100Q_' . $size . 'h_' . $size . 'w';
                 break;
             case 'kugou':
+                if (!isset($size) || empty($size)) {
+                    $size = 300;
+                };
                 $format = $this->format;
                 $data = $this->format(false)->song($id);
                 $this->format = $format;
@@ -942,6 +956,9 @@ class Meting
                 $url = str_replace('{size}', '400', $url);
                 break;
             case 'baidu':
+                if (!isset($size) || empty($size)) {
+                    $size = 300;
+                };
                 $format = $this->format;
                 $data = $this->format(false)->song($id);
                 $this->format = $format;
@@ -949,6 +966,9 @@ class Meting
                 $url = isset($data['songinfo']['pic_radio']) ? $data['songinfo']['pic_radio'] : $data['songinfo']['pic_small'];
                 break;
             case 'kuwo':
+                if (!isset($size) || empty($size)) {
+                    $size = 300;
+                };
                 $format = $this->format;
                 $data = $this->format(false)->song($id);
                 $this->format = $format;


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

将 Meting 升级到 1.5.11 版本，包含新的歌词模式、搜索支持、HTTPS 端点、增强的参数处理以及前端播放器集成

新功能：
- 在 API 和 index.php 中引入字级歌词切换 (yrc)
- 在 index.php 中添加搜索端点，包含 keyword、page 和 limit 参数
- 支持 URL 和 pic 请求的自定义比特率 (br) 和图片大小 (picsize) 参数
- 在 public/index.php 中集成 APlayer 以进行内联播放列表播放

增强功能：
- 版本升级到 1.5.11，并将所有 API 请求从 HTTP 切换到 HTTPS
- 增加默认分页限制和批量播放列表获取，以支持大型曲目列表
- 通过 filter_input 清理所有 GET 参数并传播 yrc 标志
- 重构 AES 加密/解密以使用 openssl 并删除 mcrypt 依赖项
- 添加和更新 Kuwo 服务器处理，包括 song、url、lyric 和 pic 方法
- 扩展 song2data 和 index.php 逻辑以处理新参数和搜索结果

文档：
- 更新 public/index.php 文档，以包含新的 search、br、picsize 和 yrc 参数

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade Meting to version 1.5.11 with new lyric modes, search support, HTTPS endpoints, enhanced parameter handling, and front-end player integration

New Features:
- Introduce word-level lyrics toggle (yrc) in API and index.php
- Add search endpoint in index.php with keyword, page, and limit parameters
- Support custom bitrate (br) and picture size (picsize) parameters for URL and pic requests
- Integrate APlayer in public/index.php for inline playlist playback

Enhancements:
- Bump version to 1.5.11 and switch all API requests from HTTP to HTTPS
- Increase default pagination limits and batch playlist fetching to support large track lists
- Sanitize all GET parameters via filter_input and propagate yrc flag
- Refactor AES encryption/decryption to use openssl and remove mcrypt dependencies
- Add and update Kuwo server handling across song, url, lyric, and pic methods
- Extend song2data and index.php logic to handle new parameters and search results

Documentation:
- Update public/index.php documentation for new search, br, picsize, and yrc parameters

</details>